### PR TITLE
Add required package: kmod-sched-prio

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This script requires at least the following packages:
 - **kmod-sched-core**
 - **kmod-sched-cake**
 - **kmod-sched-ctinfo**
+- **kmod-sched-prio**
 - **kmod-nft-bridge**
 
 ## Installation on OpenWrt


### PR DESCRIPTION
After setting things up, I noticed the following error in the service logs upon startup after adding `set -x` to the script:
```
+ tc qdisc add dev br-lan handle 1: root prio
RTNETLINK answers: No such file or directory
```

Adding kmod-sched-prio to my OpenWRT build resolved the issue.